### PR TITLE
fix: use variable declaration for URLON object

### DIFF
--- a/src/urlon.js
+++ b/src/urlon.js
@@ -1,4 +1,4 @@
-URLON = {
+var URLON = {
 	stringify: function (input) {
 		function encodeString (str) {
 			return encodeURI(str.replace(/([=:&@_;\/])/g, '/$1'));


### PR DESCRIPTION
Sometimes project bundled with webpack complies on undefined `URLON` variable which breaks app.
